### PR TITLE
Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.vscode
+Dockerfile
+built/
+data/
+node_modules/
+config.json
+memory.json
+memory/
+font.ttf
+docker-compose.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: mei23/ia
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,12 @@
+name: Docker Image CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ config.json
 built
 node_modules
 memory.json
+memory/
 data
 font.ttf
 yarn-error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:16.13.0-bullseye
+
+WORKDIR /ai
+
+RUN apt-get update
+RUN apt-get install -y build-essential mecab mecab-ipadic fonts-mplus
+
+COPY . ./
+RUN yarn install
+RUN yarn build
+RUN ln -s /usr/share/fonts/truetype/mplus/mplus-1p-regular.ttf font.ttf
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16.13.0-bullseye
 
 RUN apt-get update
-RUN apt-get install -y build-essential mecab libmecab-dev mecab-ipadic-utf8 sudo git make curl xz-utils file fonts-mplus
+RUN apt-get install -y build-essential mecab libmecab-dev mecab-ipadic-utf8 sudo git make curl xz-utils file fonts-noto
 
 WORKDIR /mecab-ipadic-neologd
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git
@@ -11,6 +11,8 @@ WORKDIR /ai
 COPY . ./
 RUN yarn install
 RUN yarn build
-RUN ln -s /usr/share/fonts/truetype/mplus/mplus-1p-regular.ttf font.ttf
+
+# font.ttfがないとコケるバージョン用 (存在しない文字はfallbackするので別に欧文フォントでいい)
+RUN ln -s /usr/share/fonts/truetype/noto/NotoSans-Regular.ttf font.ttf
 
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y build-essential mecab libmecab-dev mecab-ipadic-utf8 sudo
 
 WORKDIR /mecab-ipadic-neologd
 RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git
-RUN cd mecab-ipadic-neologd && ./bin/install-mecab-ipadic-neologd -n -y
+RUN cd mecab-ipadic-neologd && ./bin/install-mecab-ipadic-neologd -n -y -a
 
 WORKDIR /ai
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:16.13.0-bullseye
 
-WORKDIR /ai
-
 RUN apt-get update
-RUN apt-get install -y build-essential mecab mecab-ipadic fonts-mplus
+RUN apt-get install -y build-essential mecab libmecab-dev mecab-ipadic-utf8 sudo git make curl xz-utils file fonts-mplus
 
+WORKDIR /mecab-ipadic-neologd
+RUN git clone --depth 1 https://github.com/neologd/mecab-ipadic-neologd.git
+RUN cd mecab-ipadic-neologd && ./bin/install-mecab-ipadic-neologd -n -y
+
+WORKDIR /ai
 COPY . ./
 RUN yarn install
 RUN yarn build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   ai:
     build: .
     restart: always
+    environment:
+      FC_LANG: ja
     volumes:
       - ./config.json:/ai/config.json:ro
       - ./memory:/ai/memory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  ai:
+    build: .
+    restart: always
+    volumes:
+      - ./config.json:/ai/config.json:ro
+      - ./memory:/ai/memory

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -82,7 +82,7 @@ export default class 藍 {
 		this.account = account;
 		this.modules = modules;
 
-		const file = process.env.NODE_ENV === 'test' ? 'test.memory.json' : 'memory.json';
+		const file = fs.existsSync('memory/memory.json') ? 'memory/memory.json' : 'memory.json';
 
 		this.log(`Lodaing the memory from ${file}...`);
 


### PR DESCRIPTION
Docker
Resolve #213

とりあえず

- フォントが参照できてチャートがまともに使える
  - Notoの全部入りにfallbackするのでどんな言語でも表示できる
- キーワードが mecab-ipadic-NEologd で結構使える

感じに

loki DBファイルのmountはディレクトリにしないとうまく保存されないため、memory.json は memory/memory.json に 格納する必要がある。実行前に`touch memory/memory.json`とかしておく必要がある。
アプリとしては memory/memory.json → memory.json の順番に探索される。

MeCab系のconfigは以下を指定する
```
	"mecab": "/usr/bin/mecab",
	"mecabDic": "/usr/lib/x86_64-linux-gnu/mecab/dic/mecab-ipadic-neologd",
	"mecabNeologd": true
```

